### PR TITLE
fix: build error when "babel-config-*" calling "babel.js" on MS Windows

### DIFF
--- a/run.js
+++ b/run.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 const spawnSync = require('child_process').spawnSync;
-const babelcli = require.resolve('@babel/cli/bin/babel.js');
+
+const babelcli = (process.platform === 'win32') ? require.resolve('.bin/babel.cmd') : require.resolve('@babel/cli/bin/babel.js');
 
 const run = function(args) {
   if (process.env.TEST_BUNDLE_ONLY) {


### PR DESCRIPTION
When it build on Windows
Sometimes below error occured

It is because "cmd" file calls "js" file.

at "...\node_modules\@babel\cli\bin\babel.js"[1:1]
message like "Invalid character" with code (800A03F6) (Microsoft JScript Compile Error)