### PR TITLE
Remove Kaios query

### DIFF
--- a/es.js
+++ b/es.js
@@ -13,7 +13,6 @@ const defaultBrowsersList = [
   'not baidu 7',
   'not and_qq 11',
   'not and_uc 12',
-  'not kaios 2',
   'not op_mini all',
   'not op_mob 64'
 ];


### PR DESCRIPTION
Remove the kaios query since it is no longer valid with 7.21.3+ Babel version